### PR TITLE
feat(gatus): add support for Gateway API

### DIFF
--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -19,78 +19,89 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ## Configuration
 
-| Parameter                                | Description                                                                                | Default                            |
-|------------------------------------------|--------------------------------------------------------------------------------------------|------------------------------------|
-| `deployment.strategy`                    | Deployment strategy                                                                        | `RollingUpdate`                    |
-| `deployment.annotateConfigChecksum`      | Restart pod when config changed                                                            | `true`                             |
-| `readinessProbe.enabled`                 | Enable readiness probe                                                                     | `true`                             |
-| `livenessProbe.enabled`                  | Enable liveness probe                                                                      | `true`                             |
-| `image.repository`                       | Image repository                                                                           | `twinproduction/gatus`             |
-| `image.tag`                              | Overrides the Gatus image tag                                                              | ``                                 |
-| `image.sha`                              | Image sha                                                                                  | ``                                 |
-| `image.pullPolicy`                       | Image pull policy                                                                          | `IfNotPresent`                     |
-| `image.pullSecrets`                      | Image pull secrets                                                                         | `{}`                               |
-| `hostNetwork.enabled`                    | Enable host network mode                                                                   | `false`                            |
-| `annotations`                            | Deployment annotations                                                                     | `{}`                               |
-| `labels`                                 | Deployment labels                                                                          | `{}`                               |
-| `podAnnotations`                         | Pod annotations                                                                            | `{}`                               |
-| `podLabels`                              | Pod labels                                                                                 | `{}`                               |
-| `extraLabels`                            | Extra labels for all manifests                                                             | `{}`                               |
-| `serviceAccount.create`                  | Create service account                                                                     | `false`                            |
-| `serviceAccount.name`                    | Service account name to use                                                                | ``                                 |
-| `serviceAccount.annotations`             | ServiceAccount annotations                                                                 | `{}`                               |
-| `serviceAccount.autoMount`               | Automount the service account token in the pod                                             | `false`                            |
-| `podSecurityContext.fsGroup`             | Pod volume's ownership GID                                                                 | `65534`                            |
-| `securityContext.runAsNonRoot`           | Container runs as a non-root user                                                          | `true`                             |
-| `securityContext.runAsUser`              | Container processes' UID to run the entrypoint                                             | `65534`                            |
-| `securityContext.runAsGroup`             | Container processes' GID to run the entrypoint                                             | `65534`                            |
-| `securityContext.readOnlyRootFilesystem` | Container's root filesystem is read-only                                                   | `true`                             |
-| `service.type`                           | Type of service                                                                            | `ClusterIP`                        |
-| `service.port`                           | Port for kubernetes service                                                                | `80`                               |
-| `service.targetPort`                     | Port for container                                                                         | `8080`                             |
-| `service.annotations`                    | Service annotations                                                                        | `{}`                               |
-| `service.labels`                         | Custom labels                                                                              | `{}`                               |
-| `ingress.enabled`                        | Enables Ingress                                                                            | `false`                            |
-| `ingress.ingressClassName`               | Ingress ClassName (for k8s 1.18+)                                                          | ``                                 |
-| `ingress.name`                           | Ingress name                                                                               | ``                                 |
-| `ingress.annotations`                    | Ingress annotations (values are templated)                                                 | `{}`                               |
-| `ingress.labels`                         | Custom labels                                                                              | `{}`                               |
-| `ingress.path`                           | Ingress accepted path                                                                      | `/`                                |
-| `ingress.pathType`                       | Ingress type of path                                                                       | `Prefix`                           |
-| `ingress.extraPaths`                     | Ingress extra paths to prepend to every host                                               | `[]`                               |
-| `ingress.hosts`                          | Ingress accepted hostnames                                                                 | `["chart-example.local"]`          |
-| `ingress.tls`                            | Ingress TLS configuration                                                                  | `[]`                               |
-| `env`                                    | Extra environment variables passed to pods                                                 | `{}`                               |
-| `envFrom`                                | Additional envFrom configuration to use a Secret or a ConfigMap in an environment variable | `[]`                               |
-| `sidecarContainers`                      | Sidecar containers in the pod                                                              | `{}`                               |
-| `extraVolumeMounts`                      | Extra volume mounts                                                                        | `[]`                               |
-| `secrets`                                | Include secret's content in pod environment                                                | `false`                            |
-| `resources`                              | CPU/Memory resource requests/limits                                                        | `{}`                               |
-| `nodeSelector`                           | Node labels for pod assignment                                                             | `{}`                               |
-| `tolerations`                            | Tolerations for pod assignment                                                             | `[]`                               |
-| `extraInitContainers`                    | Init containers to add to the gatus pod                                                    | `[]`                               |
-| `persistence.enabled`                    | Use persistent volume to store data                                                        | `false`                            |
-| `persistence.size`                       | Size of persistent volume claim                                                            | `200Mi`                            |
-| `persistence.mounthPath`                 | Persistent data volume's mount path                                                        | `/data`                            |
-| `persistence.subPath`                    | Mount a sub dir of the persistent volume                                                   | `nil`                              |
-| `persistence.accessModes`                | Persistence access modes                                                                   | `[ReadWriteOnce]`                  |
-| `persistence.finalizers`                 | PersistentVolumeClaim finalizers                                                           | `["kubernetes.io/pvc-protection"]` |
-| `persistence.annotations`                | PersistentVolumeClaim annotations                                                          | `{}`                               |
-| `persistence.selectorLabels`             | PersistentVolumeClaim selector labels                                                      | `{}`                               |
-| `persistence.existingClaim`              | Use an existing PVC to persist data                                                        | `nil`                              |
-| `persistence.storageClassName`           | Type of persistent volume claim                                                            | `nil`                              |
-| `serviceMonitor.enabled`                 | Use servicemonitor from prometheus operator                                                | `false`                            |
-| `serviceMonitor.namespace`               | Namespace this servicemonitor is installed in                                              | ``                                 |
-| `serviceMonitor.interval`                | How frequently Prometheus should scrape                                                    | `1m`                               |
-| `serviceMonitor.path`                    | Path to scrape                                                                             | `/metrics`                         |
-| `serviceMonitor.scheme`                  | Scheme to use for metrics scraping                                                         | `http`                             |
-| `serviceMonitor.tlsConfig`               | TLS configuration block for the endpoint                                                   | `{}`                               |
-| `serviceMonitor.labels`                  | Labels for the servicemonitor object                                                       | `{}`                               |
-| `serviceMonitor.scrapeTimeout`           | Timeout after which the scrape is ended                                                    | `30s`                              |
-| `serviceMonitor.relabelings`             | RelabelConfigs for samples before ingestion                                                | `[]`                               |
-| `networkPolicy.enabled`                  | Enable creation of NetworkPolicy resources                                                 | `false`                            |
-| `networkPolicy.ingress.selectors`        | List of Ingress Rule selectors                                                             | `[]`                               |
-| `config`                                 | [Gatus configuration][gatus-config]                                                        | `{}`                               |
+| Parameter                                | Description                                                                                | Default                                      |
+|------------------------------------------|--------------------------------------------------------------------------------------------|----------------------------------------------|
+| `deployment.strategy`                    | Deployment strategy                                                                        | `RollingUpdate`                              |
+| `deployment.annotateConfigChecksum`      | Restart pod when config changed                                                            | `true`                                       |
+| `readinessProbe.enabled`                 | Enable readiness probe                                                                     | `true`                                       |
+| `livenessProbe.enabled`                  | Enable liveness probe                                                                      | `true`                                       |
+| `image.repository`                       | Image repository                                                                           | `twinproduction/gatus`                       |
+| `image.tag`                              | Overrides the Gatus image tag                                                              | ``                                           |
+| `image.sha`                              | Image sha                                                                                  | ``                                           |
+| `image.pullPolicy`                       | Image pull policy                                                                          | `IfNotPresent`                               |
+| `image.pullSecrets`                      | Image pull secrets                                                                         | `{}`                                         |
+| `hostNetwork.enabled`                    | Enable host network mode                                                                   | `false`                                      |
+| `annotations`                            | Deployment annotations                                                                     | `{}`                                         |
+| `labels`                                 | Deployment labels                                                                          | `{}`                                         |
+| `podAnnotations`                         | Pod annotations                                                                            | `{}`                                         |
+| `podLabels`                              | Pod labels                                                                                 | `{}`                                         |
+| `extraLabels`                            | Extra labels for all manifests                                                             | `{}`                                         |
+| `serviceAccount.create`                  | Create service account                                                                     | `false`                                      |
+| `serviceAccount.name`                    | Service account name to use                                                                | ``                                           |
+| `serviceAccount.annotations`             | ServiceAccount annotations                                                                 | `{}`                                         |
+| `serviceAccount.autoMount`               | Automount the service account token in the pod                                             | `false`                                      |
+| `podSecurityContext.fsGroup`             | Pod volume's ownership GID                                                                 | `65534`                                      |
+| `securityContext.runAsNonRoot`           | Container runs as a non-root user                                                          | `true`                                       |
+| `securityContext.runAsUser`              | Container processes' UID to run the entrypoint                                             | `65534`                                      |
+| `securityContext.runAsGroup`             | Container processes' GID to run the entrypoint                                             | `65534`                                      |
+| `securityContext.readOnlyRootFilesystem` | Container's root filesystem is read-only                                                   | `true`                                       |
+| `service.type`                           | Type of service                                                                            | `ClusterIP`                                  |
+| `service.port`                           | Port for kubernetes service                                                                | `80`                                         |
+| `service.targetPort`                     | Port for container                                                                         | `8080`                                       |
+| `service.annotations`                    | Service annotations                                                                        | `{}`                                         |
+| `service.labels`                         | Custom labels                                                                              | `{}`                                         |
+| `ingress.enabled`                        | Enables Ingress                                                                            | `false`                                      |
+| `ingress.ingressClassName`               | Ingress ClassName (for k8s 1.18+)                                                          | ``                                           |
+| `ingress.name`                           | Ingress name                                                                               | ``                                           |
+| `ingress.annotations`                    | Ingress annotations (values are templated)                                                 | `{}`                                         |
+| `ingress.labels`                         | Custom labels                                                                              | `{}`                                         |
+| `ingress.path`                           | Ingress accepted path                                                                      | `/`                                          |
+| `ingress.pathType`                       | Ingress type of path                                                                       | `Prefix`                                     |
+| `ingress.extraPaths`                     | Ingress extra paths to prepend to every host                                               | `[]`                                         |
+| `ingress.hosts`                          | Ingress accepted hostnames                                                                 | `["chart-example.local"]`                    |
+| `ingress.tls`                            | Ingress TLS configuration                                                                  | `[]`                                         |
+| `route.main.enabled`                     | Enables Gateway API Route                                                                  | `false`                                      |
+| `route.main.apiVersion`                  | Route apiVersion                                                                           | `gateway.networking.k8s.io/v1`               |
+| `route.main.kind`                        | Route Kind                                                                                 | `HTTPRoute`                                  |
+| `route.main.annotations`                 | Route annotations                                                                          | `{}`                                         |
+| `route.main.labels`                      | Route labels                                                                               | `{}`                                         |
+| `route.main.hostnames`                   | Route hostnames                                                                            | `["gatus.local"]`                            |
+| `route.main.parentRefs`                  | References to parent gateways                                                              | `[]`                                         |
+| `route.main.httpsRedirect`               | Create http route for redirect. Only enable this on the http listener of the gateway       | `false`                                      |
+| `route.main.matches`                     | Route matches                                                                              | `[{path: {type: "PathPrefix", value: "/"}}]` |
+| `route.main.filters`                     | Route filters                                                                              | `[]`                                         |
+| `route.main.additionalRules`             | Additional custom rules                                                                    | `[]`                                         |
+| `env`                                    | Extra environment variables passed to pods                                                 | `{}`                                         |
+| `envFrom`                                | Additional envFrom configuration to use a Secret or a ConfigMap in an environment variable | `[]`                                         |
+| `sidecarContainers`                      | Sidecar containers in the pod                                                              | `{}`                                         |
+| `extraVolumeMounts`                      | Extra volume mounts                                                                        | `[]`                                         |
+| `secrets`                                | Include secret's content in pod environment                                                | `false`                                      |
+| `resources`                              | CPU/Memory resource requests/limits                                                        | `{}`                                         |
+| `nodeSelector`                           | Node labels for pod assignment                                                             | `{}`                                         |
+| `tolerations`                            | Tolerations for pod assignment                                                             | `[]`                                         |
+| `extraInitContainers`                    | Init containers to add to the gatus pod                                                    | `[]`                                         |
+| `persistence.enabled`                    | Use persistent volume to store data                                                        | `false`                                      |
+| `persistence.size`                       | Size of persistent volume claim                                                            | `200Mi`                                      |
+| `persistence.mounthPath`                 | Persistent data volume's mount path                                                        | `/data`                                      |
+| `persistence.subPath`                    | Mount a sub dir of the persistent volume                                                   | `nil`                                        |
+| `persistence.accessModes`                | Persistence access modes                                                                   | `[ReadWriteOnce]`                            |
+| `persistence.finalizers`                 | PersistentVolumeClaim finalizers                                                           | `["kubernetes.io/pvc-protection"]`           |
+| `persistence.annotations`                | PersistentVolumeClaim annotations                                                          | `{}`                                         |
+| `persistence.selectorLabels`             | PersistentVolumeClaim selector labels                                                      | `{}`                                         |
+| `persistence.existingClaim`              | Use an existing PVC to persist data                                                        | `nil`                                        |
+| `persistence.storageClassName`           | Type of persistent volume claim                                                            | `nil`                                        |
+| `serviceMonitor.enabled`                 | Use servicemonitor from prometheus operator                                                | `false`                                      |
+| `serviceMonitor.namespace`               | Namespace this servicemonitor is installed in                                              | ``                                           |
+| `serviceMonitor.interval`                | How frequently Prometheus should scrape                                                    | `1m`                                         |
+| `serviceMonitor.path`                    | Path to scrape                                                                             | `/metrics`                                   |
+| `serviceMonitor.scheme`                  | Scheme to use for metrics scraping                                                         | `http`                                       |
+| `serviceMonitor.tlsConfig`               | TLS configuration block for the endpoint                                                   | `{}`                                         |
+| `serviceMonitor.labels`                  | Labels for the servicemonitor object                                                       | `{}`                                         |
+| `serviceMonitor.scrapeTimeout`           | Timeout after which the scrape is ended                                                    | `30s`                                        |
+| `serviceMonitor.relabelings`             | RelabelConfigs for samples before ingestion                                                | `[]`                                         |
+| `networkPolicy.enabled`                  | Enable creation of NetworkPolicy resources                                                 | `false`                                      |
+| `networkPolicy.ingress.selectors`        | List of Ingress Rule selectors                                                             | `[]`                                         |
+| `config`                                 | [Gatus configuration][gatus-config]                                                        | `{}`                                         |
 
 _See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)._
 

--- a/charts/gatus/templates/route.yaml
+++ b/charts/gatus/templates/route.yaml
@@ -1,0 +1,52 @@
+{{- $fullName := include "names.fullname" . -}}
+{{- $servicePort := .Values.service.port -}}
+{{- range $name, $route := .Values.route }}
+{{- if $route.enabled }}
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ $fullName }}{{ if ne $name "main" }}-{{ $name }}{{ end }}
+  namespace: {{ include "names.namespace" $ }}
+  labels:
+    {{- include "labels.baseLabels" $ | nindent 4 }}
+    {{- with $route.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $route.additionalRules }}
+    {{- tpl (toYaml $route.additionalRules) $ | nindent 4 }}
+    {{- end }}
+    {{- if $route.httpsRedirect }}
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+    {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $servicePort }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -90,6 +90,36 @@ ingress:
   #    hosts:
   #      - gatus.local
 
+route:
+  main:
+    enabled: false
+    # Set the route apiVersion
+    apiVersion: gateway.networking.k8s.io/v1
+    # Route kind
+    kind: HTTPRoute
+    # Route annotations
+    annotations: {}
+    # Route labels
+    labels: {}
+    # Route hostnames
+    hostnames:
+      - gatus.local
+    # References to parent gateways
+    parentRefs: []
+    # Create http route for redirect (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects).
+    # Take care that you only enable this on the http listener of the gateway to avoid an infinite redirect.
+    # Matches, filters and additionalRules will be ignored if this is set to true
+    httpsRedirect: false
+    # Route matches
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # Route filters
+    filters: []
+    # Additional custom rules that can be added to the route
+    additionalRules: []
+
 # Extra environment variables that will be pass onto deployment pods
 # Expects key: value
 env: {}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Add support for Gateway API: https://gateway-api.sigs.k8s.io/.

Example usage:

```yaml
route:
  main:
    enabled: true
    hostnames:
      - gatus.local
    parentRefs:
      - name: my-gw
        sectionName: https
  https-redirect:
    enabled: true
    hostnames:
      - authentik.company
    parentRefs:
      - name: my-gw
        sectionName: http
    httpsRedirect: true
```


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable. Done manually
- [x] Updated documentation in `README.md`, if applicable.
