### PR TITLE
feat(gatus): make replica count configurable in deployment values

### DIFF
--- a/charts/gatus/templates/deployment.yaml
+++ b/charts/gatus/templates/deployment.yaml
@@ -13,7 +13,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.deployment.replicas }}
   revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -4,6 +4,7 @@ deployment:
   strategy: RollingUpdate
   annotateConfigChecksum: true
   revisionHistoryLimit: 10
+  replicas: 1
 
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
 readinessProbe:


### PR DESCRIPTION
This pull request makes the number of deployment replicas configurable in the Gatus Helm chart by introducing a new `replicas` field in `values.yaml` and updating the deployment template to use this value. This allows users to easily scale the deployment via Helm values.

**Helm chart configurability:**

* Added a new `replicas` field under `deployment` in `charts/gatus/values.yaml` to specify the desired number of replicas.
* Updated `charts/gatus/templates/deployment.yaml` to use the configurable `deployment.replicas` value instead of hardcoding the replica count.


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.
