### PR TITLE
feat(gatus): Add HTTPRoute support for Kubernetes Gateway API

### DIFF
--- a/charts/gatus/Chart.yaml
+++ b/charts/gatus/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: gatus
 description: Automated service health dashboard
 icon: https://raw.githubusercontent.com/TwiN/gatus/a1c8422c2ff2b9d0a6f184c99e4dc728d3f2cd75/web/static/logo-192x192.png
-version: 1.4.4
-appVersion: v5.27.2
+version: 1.5.0
+appVersion: v5.34.0
 type: application
 engine: gotpl
 home: https://github.com/TwiN/gatus

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -61,15 +61,15 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | `ingress.extraPaths`                     | Ingress extra paths to prepend to every host                                               | `[]`                               |
 | `ingress.hosts`                          | Ingress accepted hostnames                                                                 | `["chart-example.local"]`          |
 | `ingress.tls`                            | Ingress TLS configuration                                                                  | `[]`                               |
-| `route.enabled`                          | Enables Gateway API [HTTPRoute][gateway-api]                                               | `false`                            |
-| `route.annotations`                      | HTTPRoute annotations (values are templated)                                               | `{}`                               |
-| `route.labels`                           | Custom labels                                                                              | `{}`                               |
-| `route.path`                             | Path prefix for routing                                                                    | `/`                                |
-| `route.parentRefs`                       | Parent Gateway references (required)                                                       | `[]`                               |
-| `route.hosts`                            | HTTPRoute accepted hostnames (values are templated)                                        | `["gatus.local"]`                  |
-| `route.httpsRedirect`                    | Create separate HTTPRoute for HTTP to HTTPS redirect                                       | `false`                            |
-| `route.additionalRules`                  | Additional rules to prepend before default backend rule                                    | `[]`                               |
-| `route.filters`                          | Filters to apply to the default backend rule                                               | `[]`                               |
+| `gateway.route.enabled`                  | Enables Gateway API [HTTPRoute][gateway-api]                                               | `false`                            |
+| `gateway.route.annotations`              | HTTPRoute annotations (values are templated)                                               | `{}`                               |
+| `gateway.route.labels`                   | Custom labels                                                                              | `{}`                               |
+| `gateway.route.path`                     | Path prefix for routing                                                                    | `/`                                |
+| `gateway.route.parentRefs`               | Parent Gateway references (required)                                                       | `[]`                               |
+| `gateway.route.hosts`                    | HTTPRoute accepted hostnames (values are templated)                                        | `["gatus.local"]`                  |
+| `gateway.route.httpsRedirect`            | Create separate HTTPRoute for HTTP to HTTPS redirect                                       | `false`                            |
+| `gateway.route.additionalRules`          | Additional rules to prepend before default backend rule                                    | `[]`                               |
+| `gateway.route.filters`                  | Filters to apply to the default backend rule                                               | `[]`                               |
 | `env`                                    | Extra environment variables passed to pods                                                 | `{}`                               |
 | `envFrom`                                | Additional envFrom configuration to use a Secret or a ConfigMap in an environment variable | `[]`                               |
 | `sidecarContainers`                      | Sidecar containers in the pod                                                              | `{}`                               |

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -61,6 +61,15 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | `ingress.extraPaths`                     | Ingress extra paths to prepend to every host                                               | `[]`                               |
 | `ingress.hosts`                          | Ingress accepted hostnames                                                                 | `["chart-example.local"]`          |
 | `ingress.tls`                            | Ingress TLS configuration                                                                  | `[]`                               |
+| `route.enabled`                          | Enables Gateway API [HTTPRoute][gateway-api]                                               | `false`                            |
+| `route.annotations`                      | HTTPRoute annotations (values are templated)                                               | `{}`                               |
+| `route.labels`                           | Custom labels                                                                              | `{}`                               |
+| `route.path`                             | Path prefix for routing                                                                    | `/`                                |
+| `route.parentRefs`                       | Parent Gateway references (required)                                                       | `[]`                               |
+| `route.hosts`                            | HTTPRoute accepted hostnames (values are templated)                                        | `["gatus.local"]`                  |
+| `route.httpsRedirect`                    | Create separate HTTPRoute for HTTP to HTTPS redirect                                       | `false`                            |
+| `route.additionalRules`                  | Additional rules to prepend before default backend rule                                    | `[]`                               |
+| `route.filters`                          | Filters to apply to the default backend rule                                               | `[]`                               |
 | `env`                                    | Extra environment variables passed to pods                                                 | `{}`                               |
 | `envFrom`                                | Additional envFrom configuration to use a Secret or a ConfigMap in an environment variable | `[]`                               |
 | `sidecarContainers`                      | Sidecar containers in the pod                                                              | `{}`                               |
@@ -131,3 +140,4 @@ releases:
 
 
 [gatus-config]: https://github.com/TwiN/gatus#configuration
+[gateway-api]: https://gateway-api.sigs.k8s.io/api-types/httproute/

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -61,6 +61,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | `ingress.extraPaths`                     | Ingress extra paths to prepend to every host                                               | `[]`                               |
 | `ingress.hosts`                          | Ingress accepted hostnames                                                                 | `["chart-example.local"]`          |
 | `ingress.tls`                            | Ingress TLS configuration                                                                  | `[]`                               |
+| `gateway.apiVersion`                     | Gateway API Version                                                                        | `gateway.networking.k8s.io/v1`     |
 | `gateway.route.enabled`                  | Enables Gateway API [HTTPRoute][gateway-api]                                               | `false`                            |
 | `gateway.route.annotations`              | HTTPRoute annotations (values are templated)                                               | `{}`                               |
 | `gateway.route.labels`                   | Custom labels                                                                              | `{}`                               |

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -69,6 +69,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | `gateway.route.parentRefs`               | Parent Gateway references (required)                                                       | `[]`                               |
 | `gateway.route.hosts`                    | HTTPRoute accepted hostnames (values are templated)                                        | `["gatus.local"]`                  |
 | `gateway.route.httpsRedirect`            | Create separate HTTPRoute for HTTP to HTTPS redirect                                       | `false`                            |
+| `gateway.route.httpsRedirectParentRefs`  | Parent Gateway references for redirect route (uses parentRefs if not specified)            | `[]`                               |
 | `gateway.route.additionalRules`          | Additional rules to prepend before default backend rule                                    | `[]`                               |
 | `gateway.route.filters`                  | Filters to apply to the default backend rule                                               | `[]`                               |
 | `env`                                    | Extra environment variables passed to pods                                                 | `{}`                               |

--- a/charts/gatus/templates/route.yaml
+++ b/charts/gatus/templates/route.yaml
@@ -29,15 +29,15 @@ spec:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    - filters:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.gateway.route.path | default "/" }}
+      filters:
         - type: RequestRedirect
           requestRedirect:
             scheme: https
             statusCode: 301
-      matches:
-        - path:
-            type: PathPrefix
-            value: {{ .Values.gateway.route.path | default "/" }}
 {{- end }}
 ---
 apiVersion: {{ .Values.gateway.route.apiVersion | default "gateway.networking.k8s.io/v1" }}

--- a/charts/gatus/templates/route.yaml
+++ b/charts/gatus/templates/route.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.route.enabled -}}
+  {{- $fullName := include "names.fullname" . -}}
+  {{- $servicePort := .Values.service.port -}}
+{{- if .Values.route.httpsRedirect }}
+---
+apiVersion: {{ .Values.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.route.name | default $fullName }}-https-redirect
+  namespace: {{ include "names.namespace" . }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+    {{- with .Values.route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.route.hosts }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+      matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.route.path | default "/" }}
+{{- end }}
+---
+apiVersion: {{ .Values.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ .Values.route.name | default $fullName }}
+  namespace: {{ include "names.namespace" . }}
+  labels:
+    {{- include "labels.baseLabels" . | nindent 4 }}
+    {{- with .Values.route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.route.hosts }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.route.additionalRules }}
+    {{- tpl (toYaml .Values.route.additionalRules) $ | nindent 4 }}
+    {{- end }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.route.path | default "/" }}
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $servicePort }}
+      {{- with .Values.route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/gatus/templates/route.yaml
+++ b/charts/gatus/templates/route.yaml
@@ -3,7 +3,7 @@
   {{- $servicePort := .Values.service.port -}}
 {{- if .Values.gateway.route.httpsRedirect }}
 ---
-apiVersion: {{ .Values.gateway.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+apiVersion: {{ .Values.gateway.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: HTTPRoute
 metadata:
   name: {{ .Values.gateway.route.name | default $fullName }}-https-redirect
@@ -40,7 +40,7 @@ spec:
             statusCode: 301
 {{- end }}
 ---
-apiVersion: {{ .Values.gateway.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+apiVersion: {{ .Values.gateway.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: HTTPRoute
 metadata:
   name: {{ .Values.gateway.route.name | default $fullName }}

--- a/charts/gatus/templates/route.yaml
+++ b/charts/gatus/templates/route.yaml
@@ -1,30 +1,30 @@
-{{- if .Values.route.enabled -}}
+{{- if .Values.gateway.route.enabled -}}
   {{- $fullName := include "names.fullname" . -}}
   {{- $servicePort := .Values.service.port -}}
-{{- if .Values.route.httpsRedirect }}
+{{- if .Values.gateway.route.httpsRedirect }}
 ---
-apiVersion: {{ .Values.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+apiVersion: {{ .Values.gateway.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: HTTPRoute
 metadata:
-  name: {{ .Values.route.name | default $fullName }}-https-redirect
+  name: {{ .Values.gateway.route.name | default $fullName }}-https-redirect
   namespace: {{ include "names.namespace" . }}
   labels:
     {{- include "labels.baseLabels" . | nindent 4 }}
-    {{- with .Values.route.labels }}
+    {{- with .Values.gateway.route.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.route.annotations }}
+  {{- with .Values.gateway.route.annotations }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}
   {{- end }}
 spec:
-  {{- with .Values.route.parentRefs }}
+  {{- with .Values.gateway.route.parentRefs }}
   parentRefs:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.route.hosts }}
+  {{- with .Values.gateway.route.hosts }}
   hostnames:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
@@ -37,46 +37,46 @@ spec:
       matches:
         - path:
             type: PathPrefix
-            value: {{ .Values.route.path | default "/" }}
+            value: {{ .Values.gateway.route.path | default "/" }}
 {{- end }}
 ---
-apiVersion: {{ .Values.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+apiVersion: {{ .Values.gateway.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: HTTPRoute
 metadata:
-  name: {{ .Values.route.name | default $fullName }}
+  name: {{ .Values.gateway.route.name | default $fullName }}
   namespace: {{ include "names.namespace" . }}
   labels:
     {{- include "labels.baseLabels" . | nindent 4 }}
-    {{- with .Values.route.labels }}
+    {{- with .Values.gateway.route.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.route.annotations }}
+  {{- with .Values.gateway.route.annotations }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ tpl $value $ | quote }}
     {{- end }}
   {{- end }}
 spec:
-  {{- with .Values.route.parentRefs }}
+  {{- with .Values.gateway.route.parentRefs }}
   parentRefs:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.route.hosts }}
+  {{- with .Values.gateway.route.hosts }}
   hostnames:
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
   rules:
-    {{- if .Values.route.additionalRules }}
-    {{- tpl (toYaml .Values.route.additionalRules) $ | nindent 4 }}
+    {{- if .Values.gateway.route.additionalRules }}
+    {{- tpl (toYaml .Values.gateway.route.additionalRules) $ | nindent 4 }}
     {{- end }}
     - matches:
         - path:
             type: PathPrefix
-            value: {{ .Values.route.path | default "/" }}
+            value: {{ .Values.gateway.route.path | default "/" }}
       backendRefs:
         - name: {{ $fullName }}
           port: {{ $servicePort }}
-      {{- with .Values.route.filters }}
+      {{- with .Values.gateway.route.filters }}
       filters:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/gatus/templates/route.yaml
+++ b/charts/gatus/templates/route.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  {{- with .Values.gateway.route.parentRefs }}
+  {{- with (.Values.gateway.route.httpsRedirectParentRefs | default .Values.gateway.route.parentRefs) }}
   parentRefs:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -92,6 +92,8 @@ ingress:
   #      - gatus.local
 
 gateway:
+  # Gateway API Version
+  apiVersion: gateway.networking.k8s.io/v1
   # HTTPRoute configuration
   # ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
   route:

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -91,6 +91,39 @@ ingress:
   #    hosts:
   #      - gatus.local
 
+# Gateway API HTTPRoute configuration
+# ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+route:
+  enabled: false
+  # Values can be templated
+  annotations: {}
+  labels: {}
+  # Path prefix for routing (defaults to "/")
+  path: /
+  # Parent Gateway references (required for HTTPRoute to function)
+  # ref: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+  parentRefs: []
+    # - name: my-gateway
+    #   namespace: gateway-system
+    #   sectionName: https
+  # Hostnames for the HTTPRoute
+  # Values can be templated
+  hosts:
+    - gatus.local
+  # Enable automatic HTTP to HTTPS redirect (creates a separate HTTPRoute)
+  httpsRedirect: false
+  # Additional rules to prepend before the default backend rule
+  # Values can be templated
+  additionalRules: []
+  # Filters to apply to the default backend rule
+  # ref: https://gateway-api.sigs.k8s.io/api-types/httproute/#filters-optional
+  filters: []
+    # - type: RequestHeaderModifier
+    #   requestHeaderModifier:
+    #     add:
+    #       - name: X-Forwarded-Proto
+    #         value: https
+
 # Extra environment variables that will be pass onto deployment pods
 # Expects key: value
 env: {}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -115,6 +115,13 @@ gateway:
       - gatus.local
     # Enable automatic HTTP to HTTPS redirect (creates a separate HTTPRoute)
     httpsRedirect: false
+    # Parent Gateway references for HTTPS redirect route (optional)
+    # If not specified, uses parentRefs. Typically should reference HTTP listener.
+    # ref: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    httpsRedirectParentRefs: []
+      # - name: my-gateway
+      #   namespace: gateway-system
+      #   sectionName: http
     # Additional rules to prepend before the default backend rule
     # Values can be templated
     additionalRules: []

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -91,38 +91,39 @@ ingress:
   #    hosts:
   #      - gatus.local
 
-# Gateway API HTTPRoute configuration
-# ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
-route:
-  enabled: false
-  # Values can be templated
-  annotations: {}
-  labels: {}
-  # Path prefix for routing (defaults to "/")
-  path: /
-  # Parent Gateway references (required for HTTPRoute to function)
-  # ref: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
-  parentRefs: []
-    # - name: my-gateway
-    #   namespace: gateway-system
-    #   sectionName: https
-  # Hostnames for the HTTPRoute
-  # Values can be templated
-  hosts:
-    - gatus.local
-  # Enable automatic HTTP to HTTPS redirect (creates a separate HTTPRoute)
-  httpsRedirect: false
-  # Additional rules to prepend before the default backend rule
-  # Values can be templated
-  additionalRules: []
-  # Filters to apply to the default backend rule
-  # ref: https://gateway-api.sigs.k8s.io/api-types/httproute/#filters-optional
-  filters: []
-    # - type: RequestHeaderModifier
-    #   requestHeaderModifier:
-    #     add:
-    #       - name: X-Forwarded-Proto
-    #         value: https
+gateway:
+  # HTTPRoute configuration
+  # ref: https://gateway-api.sigs.k8s.io/api-types/httproute/
+  route:
+    enabled: false
+    # Values can be templated
+    annotations: {}
+    labels: {}
+    # Path prefix for routing (defaults to "/")
+    path: /
+    # Parent Gateway references (required for HTTPRoute to function)
+    # ref: https://gateway-api.sigs.k8s.io/reference/spec/#parentreference
+    parentRefs: []
+      # - name: my-gateway
+      #   namespace: gateway-system
+      #   sectionName: https
+    # Hostnames for the HTTPRoute
+    # Values can be templated
+    hosts:
+      - gatus.local
+    # Enable automatic HTTP to HTTPS redirect (creates a separate HTTPRoute)
+    httpsRedirect: false
+    # Additional rules to prepend before the default backend rule
+    # Values can be templated
+    additionalRules: []
+    # Filters to apply to the default backend rule
+    # ref: https://gateway-api.sigs.k8s.io/api-types/httproute/#filters-optional
+    filters: []
+      # - type: RequestHeaderModifier
+      #   requestHeaderModifier:
+      #     add:
+      #       - name: X-Forwarded-Proto
+      #         value: https
 
 # Extra environment variables that will be pass onto deployment pods
 # Expects key: value


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

Adds support for Kubernetes Gateway API HTTPRoute as an alternative to traditional Ingress for exposing Gatus. This enables users running Gateway API implementations (Istio, Envoy Gateway, Cilium, nginx-gateway-fabric, etc.) to route traffic to Gatus without requiring Ingress.

### Changes
- New template: route.yaml — Creates HTTPRoute resource(s) when route.enabled: true
Values: Added route.* configuration block with full Gateway API HTTPRoute options
- Documentation: Updated README with new configuration parameters

### Features
- HTTPRoute creation with configurable parentRefs, hostnames, and path matching
- HTTPS redirect — Optional separate HTTPRoute for HTTP→HTTPS 301 redirects (route.httpsRedirect: true)
- Templated values — Annotations and hostnames support Go templating
- Additional rules — Prepend custom routing rules before the default backend
- Filters — Apply Gateway API filters (header modification, etc.) to the backend rule

Fix #36 

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
