### PR TITLE
gatus: allow using an existing kubernetes secret for the config.yaml

### DIFF
--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -105,6 +105,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | `networkPolicy.ingress.selectors`        | List of Ingress Rule selectors                                                             | `[]`                               |
 | `config`                                 | [Gatus configuration][gatus-config]                                                        | `{}`                               |
 | `externalConfigMap`                      | Name of an external ConfigMap resource. If set, `config` is ignored.                       | `""`                               |
+| `externalConfigSecret`                   | Name of an external Secret resource. If set, `config` is ignored.                          | `""`                               |
 
 _See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)._
 

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -58,9 +58,13 @@ containers:
       - configMapRef:
           name: {{ include "names.fullname" . }}
       {{- end }}
-      {{- if or .Values.secrets .Values.externalConfigSecret }}
+      {{- if .Values.secrets }}
       - secretRef:
           name: {{ include "names.fullname" . }}
+      {{- end }}
+      {{- with .Values.externalConfigSecret }}
+      - secretRef:
+          name: {{ . }}
       {{- end }}
       {{- if .Values.envFrom }}
       {{- toYaml .Values.envFrom | nindent 6 }}

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -58,7 +58,7 @@ containers:
       - configMapRef:
           name: {{ include "names.fullname" . }}
       {{- end }}
-      {{- if .Values.secrets }}
+      {{- if or .Values.secrets .Values.externalConfigSecret }}
       - secretRef:
           name: {{ include "names.fullname" . }}
       {{- end }}

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -99,8 +99,13 @@ priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
 volumes:
   - name: {{ include "names.fullname" . }}-config
+    {{- if .Values.externalConfigSecret }}
+    secret:
+      secretName: {{ .Values.externalConfigSecret }}
+    {{- else }}
     configMap:
       name: {{ .Values.externalConfigMap | default (include "names.fullname" .) }}
+    {{- end }}
   {{- if .Values.persistence.enabled }}
   - name: {{ include "names.fullname" . }}-data
     persistentVolumeClaim:

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -54,8 +54,10 @@ containers:
     {{- end }}
     {{- end }}
     envFrom:
+      {{- if not .Values.externalConfigSecret }}
       - configMapRef:
           name: {{ include "names.fullname" . }}
+      {{- end }}
       {{- if .Values.secrets }}
       - secretRef:
           name: {{ include "names.fullname" . }}

--- a/charts/gatus/templates/configmap.yaml
+++ b/charts/gatus/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.externalConfigMap }}
+{{ if and (not .Values.externalConfigMap) (not .Values.externalConfigSecret) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -250,4 +250,9 @@ config:
         - "[BODY] == pat(*<h1>Example Domain</h1>*)"
 
 # Name of an external ConfigMap resource. If set, `config` is ignored.
+# configmap key must be named config.yaml
 externalConfigMap: ""
+
+# Name of an external Secret resource. If set, `config` is ignored.
+# secret key must be named config.yaml
+externalConfigSecret: ""


### PR DESCRIPTION
## Summary

Adds a new `externalConfigSecret` to the gatus helm chart, so users can use an existing Kubernetes Secret. This is useful for if the `config.yaml` would contain a sensitive api key or URL, for instance for the alerts.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.
