### PR TITLE
Make dnsPolicy adjustable in k8s-ttl-controller chart

### DIFF
--- a/charts/k8s-ttl-controller/Chart.yaml
+++ b/charts/k8s-ttl-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: k8s-ttl-controller
-version: 0.4.0
+version: 0.5.0
 description: Annotation-based TTL controller for Kubernetes
 home: https://github.com/TwiN/k8s-ttl-controller
 maintainers:

--- a/charts/k8s-ttl-controller/templates/deployment.yaml
+++ b/charts/k8s-ttl-controller/templates/deployment.yaml
@@ -18,7 +18,9 @@ spec:
       automountServiceAccountToken: true
       serviceAccountName: {{ .Values.serviceAccount.name }}
       restartPolicy: Always
-      dnsPolicy: Default
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
       containers:
         - name: k8s-ttl-controller
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/charts/k8s-ttl-controller/values.yaml
+++ b/charts/k8s-ttl-controller/values.yaml
@@ -38,6 +38,10 @@ clusterRole:
 clusterRoleBinding:
   create: true
 
+# DNS policy for the pod. If not set, the field will be omitted and Kubernetes will use the default.
+# See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy:
+
 # Environment variables to set in the container
 env: []
 # - name: API_RESOURCES_TO_WATCH


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/cwrau/twin-helm-charts/sessions/69e0c286-111c-4af3-956e-ebccb2a8b66d

<!-- Thank you for contributing! -->

## Summary

The (old) default of `Default` doesn't work in any cluster I have tried; whereas the real default (empty field) or `ClusterFirst` works just fine

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
