### PR TITLE
chore: publish charts to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,3 +26,21 @@ jobs:
         uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/charts"
+          done


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
Adds a github action to publish helm charts to ghcr.io

Fixes #43

This is based on https://github.com/prometheus-community/helm-charts/blob/4bbd07f308884d44d0edff23ee60da967dc2cd23/.github/workflows/release.yaml#L39C1-L61C15

Action tested in https://github.com/markafarrell/gatus-helm-charts/actions/runs/25349264568/job/74326252605

Example of packages https://github.com/markafarrell?tab=packages&repo_name=gatus-helm-charts


## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Updated documentation in `README.md`, if applicable.


