### PR TITLE
feat(gatus): allow probe scheme to be set

### DIFF
--- a/charts/gatus/Chart.yaml
+++ b/charts/gatus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gatus
 description: Automated service health dashboard
 icon: https://raw.githubusercontent.com/TwiN/gatus/a1c8422c2ff2b9d0a6f184c99e4dc728d3f2cd75/web/static/logo-192x192.png
-version: 1.5.0
+version: 1.6.0
 appVersion: v5.34.0
 type: application
 engine: gotpl

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -24,7 +24,9 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | `deployment.strategy`                    | Deployment strategy                                                                        | `RollingUpdate`                    |
 | `deployment.annotateConfigChecksum`      | Restart pod when config changed                                                            | `true`                             |
 | `readinessProbe.enabled`                 | Enable readiness probe                                                                     | `true`                             |
+| `readinessProbe.scheme`                  | Scheme for probe (HTTP or HTTPS)                                                           | ``                                 |
 | `livenessProbe.enabled`                  | Enable liveness probe                                                                      | `true`                             |
+| `livenessProbe.scheme`                   | Scheme for probe (HTTP or HTTPS)                                                           | ``                                 |
 | `image.repository`                       | Image repository                                                                           | `twinproduction/gatus`             |
 | `image.tag`                              | Overrides the Gatus image tag                                                              | ``                                 |
 | `image.sha`                              | Image sha                                                                                  | ``                                 |

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -68,12 +68,18 @@ containers:
       httpGet:
         path: /health
         port: http
+        {{- if hasKey .Values.readinessProbe "scheme" }}
+        scheme: {{ .Values.readinessProbe.scheme }}
+        {{- end }}
     {{- end }}
     {{- if .Values.livenessProbe.enabled }}
     livenessProbe:
       httpGet:
         path: /health
         port: http
+        {{- if hasKey .Values.livenessProbe "scheme" }}
+        scheme: {{ .Values.livenessProbe.scheme }}
+        {{- end }}
     {{- end }}
     resources:
       {{- toYaml .Values.resources | nindent 6 }}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -8,10 +8,16 @@ deployment:
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes
 readinessProbe:
   enabled: true
+  # scheme must be set to HTTPS when web.tls.certificate-file and web.tls.private-key-file are set
+  # the default is to use HTTP
+  # scheme: HTTPS
 
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request
 livenessProbe:
   enabled: true
+  # scheme must be set to HTTPS when web.tls.certificate-file and web.tls.private-key-file are set
+  # the default is to use HTTP
+  # scheme: HTTPS
 
 image:
   repository: twinproduction/gatus


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

There is no way to modify the scheme used for probes which is required when gatus is confgured to use tls.

This add the capability to specify the scheme used for probes.
By default the existing behaviour is maintained (i.e. `scheme` is not specified)

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [x] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [x] Updated documentation in `README.md`, if applicable.

```bash
d384492@CMW-PF640G7F:~/work/gatus-helm-charts-gh$ git switch master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
d384492@CMW-PF640G7F:~/work/gatus-helm-charts-gh$ helm template --namespace gatus gatus charts/gatus > master.yml                           
d384492@CMW-PF640G7F:~/work/gatus-helm-charts-gh$ git switch feat/gatus-support-setting-probe-scheme 
Switched to branch 'feat/gatus-support-setting-probe-scheme'
d384492@CMW-PF640G7F:~/work/gatus-helm-charts-gh$ helm template --namespace gatus gatus charts/gatus > scheme-not-set.yml
d384492@CMW-PF640G7F:~/work/gatus-helm-charts-gh$ helm template --namespace gatus gatus charts/gatus --set readinessProbe.scheme=HTTPS --set livenessProbe.scheme=HTTPS > scheme-set.yml
d384492@CMW-PF640G7F:~/work/gatus-helm-charts-gh$ dyff between master.yml scheme-not-set.yml 
     _        __  __
   _| |_   _ / _|/ _|  between master.yml, three documents
 / _' | | | | |_| |_       and scheme-not-set.yml, three documents
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned no differences
        |___/

d384492@CMW-PF640G7F:~/work/gatus-helm-charts-gh$ dyff between master.yml scheme-set.yml 
     _        __  __
   _| |_   _ / _|/ _|  between master.yml, three documents
 / _' | | | | |_| |_       and scheme-set.yml, three documents
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned two differences
        |___/

spec.template.spec.containers.gatus.readinessProbe.httpGet  (apps/v1/Deployment/gatus/gatus)
  + one map entry added:
    scheme: HTTPS

spec.template.spec.containers.gatus.livenessProbe.httpGet  (apps/v1/Deployment/gatus/gatus)
  + one map entry added:
    scheme: HTTPS
```
