### PR TITLE
Adds ability to control gatus Pod DNS settings

### DIFF
--- a/charts/gatus/Chart.yaml
+++ b/charts/gatus/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: gatus
 description: Automated service health dashboard
 icon: https://raw.githubusercontent.com/TwiN/gatus/a1c8422c2ff2b9d0a6f184c99e4dc728d3f2cd75/web/static/logo-192x192.png
-version: 1.5.0
+version: 1.6.0
 appVersion: v5.34.0
 type: application
 engine: gotpl

--- a/charts/gatus/README.md
+++ b/charts/gatus/README.md
@@ -31,6 +31,10 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 | `image.pullPolicy`                       | Image pull policy                                                                          | `IfNotPresent`                     |
 | `image.pullSecrets`                      | Image pull secrets                                                                         | `{}`                               |
 | `hostNetwork.enabled`                    | Enable host network mode                                                                   | `false`                            |
+| `dnsPolicy.enabled`.                     | Enable control of the dnsPolicy                                                            | `false`                            |
+| `dnsPolicy.policy`.                      | Pod DNS Policy.                                                                            | `Default`                          |
+| `dnsConfig.enabled`.                     | Enable control of the dnsConfig property of the Pod                                        | `false`                            |
+| `dnsConfig.config`.                      | Pod dnsConfig                                                                              | `{}`                               |
 | `annotations`                            | Deployment annotations                                                                     | `{}`                               |
 | `labels`                                 | Deployment labels                                                                          | `{}`                               |
 | `podAnnotations`                         | Pod annotations                                                                            | `{}`                               |

--- a/charts/gatus/templates/_pod.tpl
+++ b/charts/gatus/templates/_pod.tpl
@@ -2,6 +2,13 @@
 {{- if .Values.hostNetwork.enabled }}
 hostNetwork: true
 {{- end }}
+{{- if .Values.dnsPolicy.enabled}}
+dnsPolicy: {{ .Values.dnsPolicy.policy }}
+{{- end }}
+{{- if .Values.dnsConfig.enabled}}
+dnsConfig: 
+  {{ toYaml .Values.dnsConfig.config | nindent 2 }}
+{{- end }}
 {{- if .Values.image.pullSecrets }}
 imagePullSecrets:
   {{- range .Values.image.pullSecrets }}

--- a/charts/gatus/values.yaml
+++ b/charts/gatus/values.yaml
@@ -29,6 +29,18 @@ image:
 hostNetwork:
   enabled: false
 
+dnsPolicy: 
+  # enable overwrite
+  enabled: false
+  # see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  policy: "Default"
+
+dnsConfig: 
+  # enable overwrite
+  enabled: false
+  # see https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  config: {}
+
 # Additional deployment annotations
 annotations: {}
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->

In my setup (k3s node with `systemd-resolved` and link-local entries in `/etc/resolv.conf`) k3s unfortunately [automatically populates](https://docs.k3s.io/advanced#nameserver-viability-checks) the `/etc/resolv.conf` of the pod with public DNS entries. In order to allow gatus to be used as a status page for my home-lab custom DNS settings were required but the chart did not allow configuring of the dnsPolicy and dnsConfig. 

Thus, this PR adds the ability to configure DNS entries specifically for the Gatus Pod, enabling a more flexible use of the tool.

This feature has been requested by #16.

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [X] Updated documentation in `README.md`, if applicable.
